### PR TITLE
セキュリティ周りの実装

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,11 @@
 const nextConfig = {
   output: "export",
   images: { unoptimized: true },
+  // 注意: 静的エクスポート（output: "export"）の場合、headers()は動作しません
+  // セキュリティヘッダーはホスティングサービスの設定ファイルで設定してください
+  // - Vercel: vercel.json
+  // - Netlify: public/_headers または netlify.toml
+  // - その他: ホスティングサービスの設定でヘッダーを追加
 };
 
 module.exports = nextConfig;

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://formspree.io https://*.formspree.io; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://formspree.io; upgrade-insecure-requests;
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,34 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://formspree.io https://*.formspree.io; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://formspree.io; upgrade-insecure-requests;"
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
# セキュリティヘッダーの追加

## 概要

脆弱性診断で指摘されたセキュリティヘッダーを実装しました。これにより、XSS攻撃、クリックジャッキング、MIMEタイプスニッフィングなどの主要なWebセキュリティリスクからサイトを保護します。

## 変更内容

### 追加されたセキュリティヘッダー

| ヘッダー | 値 | 目的 |
|---------|-----|------|
| X-Content-Type-Options | nosniff | MIMEタイプスニッフィング攻撃を防止 |
| X-Frame-Options | DENY | クリックジャッキング攻撃を防止（CSPと併用） |
| Referrer-Policy | strict-origin-when-cross-origin | リファラー情報の制御、プライバシー保護 |
| Permissions-Policy | camera=(), microphone=(), geolocation=(), interest-cohort=() | 不要なブラウザ機能を無効化 |
| Strict-Transport-Security | max-age=31536000; includeSubDomains; preload | HTTPS接続を強制、MITM攻撃を防止 |
| Content-Security-Policy | (下記参照) | XSS攻撃、データインジェクション攻撃を防止 |

### Content-Security-Policy (CSP) の詳細

```
default-src 'self';
script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live;
style-src 'self' 'unsafe-inline';
img-src 'self' data: https:;
font-src 'self' data:;
connect-src 'self' https://formspree.io https://*.formspree.io;
object-src 'none';
frame-ancestors 'none';
base-uri 'self';
form-action 'self' https://formspree.io;
upgrade-insecure-requests;
```

### 実装ファイル

- `vercel.json`: Vercelデプロイ時のヘッダー設定
- `public/_headers`: Netlifyなどの他のホスティングサービス用のヘッダー設定

## 技術的な考慮事項

### 採用しなかったヘッダー

| ヘッダー | 理由 |
|---------|------|
| X-XSS-Protection | MDNで**非推奨**。Chrome 78以降では無視され、古いIEでは逆にXSS脆弱性を引き起こす可能性がある。CSPで代替。 |

### CSPの設計判断

| 設定 | 理由 |
|------|------|
| `'unsafe-eval'`, `'unsafe-inline'` | Next.jsの動作に必要。将来的にnonceベースのCSPへの移行を検討 |
| Google Fonts不要 | Next.jsの`next/font/google`はビルド時にフォントをダウンロードし、自サイトからサーブするため外部リクエストは発生しない |
| `object-src 'none'` | Flash等のプラグインを完全に禁止 |
| `frame-ancestors 'none'` | X-Frame-Optionsと同等だが、より柔軟で推奨される方法 |
| `https://vercel.live` | Vercelのプレビューデプロイで必要 |

### X-Frame-Options vs CSP frame-ancestors

- `X-Frame-Options`はMDNで非推奨だが、古いブラウザとの互換性のために両方設定
- モダンブラウザはCSPの`frame-ancestors`を使用

## テスト

- [ ] Vercelにデプロイ後、セキュリティヘッダーが正しく設定されているか確認
- [ ] [Security Headers](https://securityheaders.com/)でスキャンし、A以上の評価を確認
- [ ] 脆弱性診断ツールで再度スキャンし、指摘事項が解消されているか確認
- [ ] サイトの機能（フォーム送信、ナビゲーションなど）が正常に動作するか確認

## 参考リンク

### 公式ドキュメント

- [Vercel - Headers設定](https://vercel.com/docs/project-configuration/headers)
- [Next.js - Headers API](https://nextjs.org/docs/app/api-reference/next-config-js/headers)

### MDN Web Docs（標準仕様）

- [X-Content-Type-Options](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/X-Content-Type-Options)
- [X-Frame-Options](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/X-Frame-Options) - **非推奨、CSPのframe-ancestorsを推奨**
- [Content-Security-Policy](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Content-Security-Policy)
- [Strict-Transport-Security](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Strict-Transport-Security)
- [Permissions-Policy](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Permissions-Policy)
- [Referrer-Policy](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Referrer-Policy)
- [X-XSS-Protection](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/X-XSS-Protection) - **非推奨**

### セキュリティガイドライン

- [OWASP - HTTP Security Headers](https://owasp.org/www-project-secure-headers/)
- [Security Headers - セキュリティヘッダーのテストツール](https://securityheaders.com/)

## チェックリスト

- [x] セキュリティヘッダーを実装
- [x] 非推奨のX-XSS-Protectionを除外
- [x] CSPにobject-src 'none'を追加
- [x] 不要なGoogle Fonts許可を削除（Next.jsが最適化）
- [x] Vercel用の設定ファイル（`vercel.json`）を作成
- [x] Netlify用の設定ファイル（`public/_headers`）を作成
- [ ] デプロイ後の動作確認
- [ ] 脆弱性診断の再実行

